### PR TITLE
[ENHANCEMENT]Simpler solution to mask question using padStart

### DIFF
--- a/questions/mask.md
+++ b/questions/mask.md
@@ -8,11 +8,11 @@ mask("123456789") // "#####6789"
 
 > There are many ways to solve this problem, this is just one one of them.
 
-Using `String.prototype.slice()`, we can grab a portion of the string from index `0` (first character) to index `-4` (5th last character) and calculate the resulting length, using `String.prototype.repeat()` to repeat the mask character that many times. Then, using `String.prototype.slice()` once more, we can concatenate the last 4 characters by passing `-4` as an argument.
+Using `String.prototype.slice()` we can grab the last 4 characters of the string by passing `-4` as an argument. Then, using `String.prototype.padStart()`, we can pad the string to the original length with the repeated mask character.
 
 ```js
 const mask = (str, maskChar = "#") =>
-  maskChar.repeat(str.slice(0, -4).length) + str.slice(-4)
+  str.slice(-4).padStart(str.length, maskChar)
 ```
 
 #### Good to hear


### PR DESCRIPTION
## Description

Using padStart, which is supported by all major browsers nowadays, we can simplify a bit the mask question. It removes the need for a second slice for the length or the manual concatenation.

## What does your PR belong to?

* [X] Questions / Answers
* [ ] Website
* [ ] General / Things regarding the repository (like CI Integration)

## Types of changes

* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] Enhancement (non-breaking improvement of a question)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

* [X] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [X] I have checked that the changes are working properly
* [X] I have checked that there isn't any PR doing the same
* [X] I have read the **CONTRIBUTING** document.
